### PR TITLE
feat: supported networks to be passed as props

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -48,3 +48,7 @@
 ## 0.3.9
 
 - `Disclaimer` component added
+
+## 0.3.10
+
+- pass supportedNetworks as props to Login component

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ The following table shows which versions of `autonolas-frontend-library` are cur
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `0.3.9`   | :white_check_mark: |
+| `0.3.10`   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/src/components/common/Login/Login.tsx
+++ b/src/components/common/Login/Login.tsx
@@ -35,6 +35,7 @@ type LoginProps = {
    */
   isDapp?: boolean;
   backendUrl?: string;
+  supportedNetworks?: number[];
 };
 
 export const Login = ({
@@ -45,6 +46,7 @@ export const Login = ({
   buttonProps,
   isDapp = true,
   backendUrl,
+  supportedNetworks,
 }: LoginProps) => {
   const web3Modal = ProviderOptions.getWeb3ModalInstance(rpc);
 
@@ -220,7 +222,7 @@ export const Login = ({
         <WalletContainer>
           {isDapp ? (
             <>
-              {!SUPPORTED_NETWORKS.includes(chainId) && (
+              {!(supportedNetworks || SUPPORTED_NETWORKS).includes(chainId) && (
                 <div className="unsupported-network">{unsupportedText}</div>
               )}
             </>


### PR DESCRIPTION
* Right now, the supported network is hardcoded in the repo but we want this to be passed as prop for L2 support in protocol-frontend 
 
<img width="1421" alt="qwerty" src="https://github.com/valory-xyz/autonolas-frontend-library/assets/22061815/60f7f0ec-8d50-4b7c-a1cb-102f26da519d">
